### PR TITLE
SP-4472: fix README.md to contain job-failed playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,30 @@ Playbooks in this section enrich, analyze and triage alerts in real-time. They h
 <table border=2 border-style=outset>
   <tr>
     <td border=0 width="110">
+      <a href="https://github.com/stackpulse/playbooks/tree/master/kubernetes/job-failed">
+      <img src="https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.png"/>
+      </a>
+    </td>
+    <td>
+      <a href="https://github.com/stackpulse/playbooks/tree/master/kubernetes/job-failed"><b>Kubernetes Job Failed</b></a><br><br>
+      This playbook extracts logs from a failed Kubernetes job and optionally allows to delete it.
+     <br><br>
+    <div style="padding-top:1px">
+        <img src="https://img.shields.io/static/v1?label=env&message=Kubernetes&style=flat&logo=Kubernetes&color=326CE5" alt="env">
+        <img src="https://img.shields.io/static/v1?label=uses&message=Slack&style=flat&logo=slack&color=4A154B" alt="slack">
+    </div>
+    <div style="margin-top:15px">
+        <a href="https://app.stackpulse.io/playbook/create#https://github.com/stackpulse/playbooks/blob/master/kubernetes/job-failed/playbook.yaml" target="_blank" style="vertical-align:middle"><img src="images/open_in_stackpulse.svg" alt="import_in_stackpulse" width="130"></a>
+    </div>
+    </td>
+  </tr>
+</table>
+
+<br>
+
+<table border=2 border-style=outset>
+  <tr>
+    <td border=0 width="110">
       <a href="https://github.com/stackpulse/playbooks/tree/master/postgres/long-running-sessions">
         <img src="images/psql.png"/>
       </a>


### PR DESCRIPTION
## Description

<!-- Please write a short summary for this change. If it's a playbook, explain what it does. -->

## Best Practices checklist
<!---  Put an `x` in all the boxes that apply: -->

### General
- [x] Go over texts with @stackpulse/product
- [x] Explicitly discuss the _playbook name_, _image_ and _badges_
- [x] Explicitly consider various _benefits_. As a rule of thumb, there should be 2-3 of them

### New playbooks
- [x] Tested Playbook in a production tenant
- [x] Added a link in the [README.MD](https://github.com/stackpulse/playbooks/blob/master/README.md)

### Playbook structure
- [x] For improved human-readability, please add a new empty line between the steps
- [x] Please add a one-liner comment block before each step, for example: `# Retrieve long connections from the database server`
- [x] When considering step IDs, please use short, but descriptive terms, explaining what is being done, such as `retrieve_connections_data` or `update_storage_size`
- [x] When writing params descriptions, start with a capital letter and phrase as a short sentence, such as `User name for database connection` or `Address of the database cluster`


## Screenshot

<!-- please include a screenshot or a GIF/MP4 of how it works. Validate the screenshot with @stackpulse/product as well: make sure that it provides a good example for the value of the playbook and has high chances of causing a reaction of "Yes, I understand how it can help me" from a person looking at it.  -->
