### PR TITLE
[SP-5301] - change order of war room name

### DIFF
--- a/stackpulse/create-incident-war-room-opsgenie/playbook.yaml
+++ b/stackpulse/create-incident-war-room-opsgenie/playbook.yaml
@@ -40,18 +40,18 @@ steps:
       MEETING_TOPIC: "StackPulse War Room for Incident {{ $.event.Name }} ({{ $.event.ID }})"
     envFrom:
       integrationRef: "{{ $.params.zoomIntegrationName }}"
-  
+
   # Creates war-room channel
   - name: us-docker.pkg.dev/stackpulse/public/slack/channel/create
     id: slack_create_war_room_channel
     env:
-      CHANNEL_NAME: "incident {{ $.event.Name }} {{$.event.ID }}"
+      CHANNEL_NAME: "incident {{ $.event.ID }} {{ $.event.Name }}"
       PURPOSE: '{{ $.event.Description }}'
       TOPIC: "StackPulse War Room Channel for Incident {{ $.event.Name }} ({{ $.event.ID }})\n Zoom meeting link - {{ $.join_url }}"
       USERS: '{{ $.params.invitees }}'
     envFrom:
       integrationRef: '{{ $.params.slackIntegrationName }}'
-  
+
   # Attach war-room channel to StackPulse incident
   - name: us-docker.pkg.dev/stackpulse/public/stackpulse/incident/update
     id: attach_war_room_channel_to_incident
@@ -70,7 +70,7 @@ steps:
       RECIPIENTS: "#{{ $.params.notificationChannel }}"
     envFrom:
       integrationRef: '{{ $.params.slackIntegrationName }}'
-  
+
   # Send message in war-room with incident details
   - name: us-docker.pkg.dev/stackpulse/public/slack/message/dynamic
     id: slack_alert_war_room_channel

--- a/stackpulse/create-incident-war-room-opsgenie/playbook.yaml
+++ b/stackpulse/create-incident-war-room-opsgenie/playbook.yaml
@@ -45,7 +45,7 @@ steps:
   - name: us-docker.pkg.dev/stackpulse/public/slack/channel/create
     id: slack_create_war_room_channel
     env:
-      CHANNEL_NAME: "incident {{ $.event.ID }} {{ $.event.Name }}"
+      CHANNEL_NAME: "{{ $.event.ID }} {{ $.event.Name }}"
       PURPOSE: '{{ $.event.Description }}'
       TOPIC: "StackPulse War Room Channel for Incident {{ $.event.Name }} ({{ $.event.ID }})\n Zoom meeting link - {{ $.join_url }}"
       USERS: '{{ $.params.invitees }}'

--- a/stackpulse/create-incident-war-room-pagerduty/playbook.yaml
+++ b/stackpulse/create-incident-war-room-pagerduty/playbook.yaml
@@ -40,7 +40,7 @@ steps:
   - name: us-docker.pkg.dev/stackpulse/public/slack/channel/create
     id: slack_create_war_room_channel
     env:
-      CHANNEL_NAME: "incident {{ $.event.ID }} {{ $.event.Name }}"
+      CHANNEL_NAME: "{{ $.event.ID }} {{ $.event.Name }}"
       PURPOSE: '{{ $.event.Description }}'
       TOPIC: "StackPulse War Room Channel for Incident {{ $.event.Name }} ({{ $.event.ID }})\n Zoom meeting link - {{ $.join_url }}"
       USERS: '{{ $.params.invitees }}'

--- a/stackpulse/create-incident-war-room-pagerduty/playbook.yaml
+++ b/stackpulse/create-incident-war-room-pagerduty/playbook.yaml
@@ -35,18 +35,18 @@ steps:
       MEETING_TOPIC: "StackPulse War Room for Incident {{ $.event.Name }} ({{ $.event.ID }})"
     envFrom:
       integrationRef: "{{ $.params.zoomIntegrationName }}"
-  
+
   # Creates war-room channel
   - name: us-docker.pkg.dev/stackpulse/public/slack/channel/create
     id: slack_create_war_room_channel
     env:
-      CHANNEL_NAME: "incident {{ $.event.Name }} {{$.event.ID }}"
+      CHANNEL_NAME: "incident {{ $.event.ID }} {{ $.event.Name }}"
       PURPOSE: '{{ $.event.Description }}'
       TOPIC: "StackPulse War Room Channel for Incident {{ $.event.Name }} ({{ $.event.ID }})\n Zoom meeting link - {{ $.join_url }}"
       USERS: '{{ $.params.invitees }}'
     envFrom:
       integrationRef: '{{ $.params.slackIntegrationName }}'
-  
+
   # Attach war-room channel to StackPulse incident
   - name: us-docker.pkg.dev/stackpulse/public/stackpulse/incident/update
     id: attach_war_room_channel_to_incident
@@ -75,7 +75,7 @@ steps:
       RECIPIENTS: "#{{ $.channel_name }}"
     envFrom:
       integrationRef: '{{ $.params.slackIntegrationName }}'
-  
+
   # Interactively ask the reporter whether to page the on caller on PagerDuty
   - name: us-docker.pkg.dev/stackpulse/public/slack/message/interactive
     id: slack_ask_on_caller_paging
@@ -87,7 +87,7 @@ steps:
       TIMEOUT: 2m
     envFrom:
       integrationRef: '{{ $.params.slackIntegrationName }}'
-  
+
   # Create incident on PagerDuty
   - name: us-docker.pkg.dev/stackpulse/public/pagerduty/incident/create
     id: pagerduty_incident_create

--- a/stackpulse/create-incident-war-room/playbook.yaml
+++ b/stackpulse/create-incident-war-room/playbook.yaml
@@ -20,7 +20,7 @@ steps:
 - name: us-docker.pkg.dev/stackpulse/public/slack/channel/create
   id: slack_create_war_room_channel
   env:
-    CHANNEL_NAME: "incident {{ $.event.ID }} {{ $.event.Name }}"
+    CHANNEL_NAME: "{{ $.event.ID }} {{ $.event.Name }}"
     PURPOSE: '{{ $.event.Description }}'
     TOPIC: "StackPulse War Room Channel for Incident {{ $.event.Name }} ({{ $.event.ID }})"
     USERS: '{{ $.params.invitees }}'

--- a/stackpulse/create-incident-war-room/playbook.yaml
+++ b/stackpulse/create-incident-war-room/playbook.yaml
@@ -20,7 +20,7 @@ steps:
 - name: us-docker.pkg.dev/stackpulse/public/slack/channel/create
   id: slack_create_war_room_channel
   env:
-    CHANNEL_NAME: "incident {{ $.event.Name }} {{$.event.ID }}"
+    CHANNEL_NAME: "incident {{ $.event.ID }} {{ $.event.Name }}"
     PURPOSE: '{{ $.event.Description }}'
     TOPIC: "StackPulse War Room Channel for Incident {{ $.event.Name }} ({{ $.event.ID }})"
     USERS: '{{ $.params.invitees }}'


### PR DESCRIPTION
have incident id before incident name

## Description

<!-- Please write a short summary for this change. If it's a playbook, explain what it does. -->

## Best Practices checklist
<!---  Put an `x` in all the boxes that apply: -->

### General
- [ ] Go over texts with @stackpulse/product
- [ ] Explicitly discuss the _playbook name_, _image_ and _badges_
- [ ] Explicitly consider various _benefits_. As a rule of thumb, there should be 2-3 of them
- [ ] If the playbook has Slack outputs use the Slack experience template

### New playbooks
- [ ] Tested Playbook in a production tenant
- [ ] Added a link in the [README.MD](https://github.com/stackpulse/playbooks/blob/master/README.md)

### Playbook structure
- [ ] For improved human-readability, please add a new empty line between the steps
- [ ] Please add a one-liner comment block before each step, for example: `# Retrieve long connections from the database server`
- [ ] When considering step IDs, please use short, but descriptive terms, explaining what is being done, such as `retrieve_connections_data` or `update_storage_size`
- [ ] When writing params descriptions, start with a capital letter and phrase as a short sentence, such as `User name for database connection` or `Address of the database cluster`


## Screenshot

<!-- please include a screenshot or a GIF/MP4 of how it works. Validate the screenshot with @stackpulse/product as well: make sure that it provides a good example for the value of the playbook and has high chances of causing a reaction of "Yes, I understand how it can help me" from a person looking at it.  -->
